### PR TITLE
Add BackUpAndShoot auto routine

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,6 +11,7 @@ import frc.robot.commands.TemplateCommand;
 import frc.robot.commands.UptakeAndFeed;
 import frc.robot.commandgroups.JogUptakeAndFeedCommand;
 import frc.robot.commandgroups.MoveOffLineAndShootPreloadsAuto;
+import frc.robot.commandgroups.BackUpAndShootAuto;
 import frc.robot.commandgroups.ShootPreloadsAuto;
 import frc.robot.commands.AHHHCommand;
 import frc.robot.commands.AutoTrackGoal;
@@ -272,7 +273,8 @@ System.out.println("Getting Autonomous Command!");
         else if (index == 2)
             chosenCommand = new ShootPreloadsAuto(false);
    
-        //     else if (index == 3)
+        else if (index == 3)
+            chosenCommand = new BackUpAndShootAuto();
         //     chosenCommand = new OneCoralAutoCenter();
         //     else if (index == 4)
         //     chosenCommand = new OneCoralAutoLeft();

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -243,6 +243,7 @@ public class RobotMap {
     public static class Intake {
         public static final double INTAKE_SPEED = 0.8; // was 0.8
         public static final double OUTTAKE_SPEED = -0.5; // was -0.5
+        public static final double INTAKE_DEPOT_SPEED = 0.5; // tune for depot pickup
     }
 
     /**

--- a/src/main/java/frc/robot/commandgroups/BackUpAndShootAuto.java
+++ b/src/main/java/frc/robot/commandgroups/BackUpAndShootAuto.java
@@ -3,6 +3,7 @@ package frc.robot.commandgroups;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -64,7 +65,7 @@ public class BackUpAndShootAuto extends SequentialCommandGroup {
                         // Deadline: finish driving to depot
                         new MoveToPose(1.5, 2.0, new Pose2d(1.30, 5.72, new Rotation2d(Math.toRadians(315.0)))),
                         // Continuously run intake while driving
-                        new InstantCommand(() -> RobotContainer.intake.intake(RobotMap.Intake.INTAKE_DEPOT_SPEED))),
+                        new RunCommand(() -> RobotContainer.intake.intake(RobotMap.Intake.INTAKE_DEPOT_SPEED), RobotContainer.intake)),
 
                 // 4. Stop intake once arrived at depot
                 new InstantCommand(() -> RobotContainer.intake.stop()),

--- a/src/main/java/frc/robot/commandgroups/BackUpAndShootAuto.java
+++ b/src/main/java/frc/robot/commandgroups/BackUpAndShootAuto.java
@@ -1,0 +1,98 @@
+package frc.robot.commandgroups;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+import frc.robot.RobotContainer;
+import frc.robot.RobotMap;
+import frc.robot.commands.MoveToPose;
+import frc.robot.commands.Pause;
+import frc.robot.commands.ShootCommand;
+import frc.robot.commands.UptakeAndFeed;
+import frc.robot.utils.AutoFunctions;
+
+/**
+ * 
+ * 
+ * All target coordinates are in Blue Alliance coordinates!!!
+ * We transform to RED usind AutoFunctions.redVsBlue()
+ * 
+ * 
+ * 
+ */
+public class BackUpAndShootAuto extends SequentialCommandGroup {
+
+    public BackUpAndShootAuto() {
+        addRequirements(RobotContainer.drivesystem);
+
+        addCommands(
+                // 1. Set odometry to start pose from Shuffleboard
+                new InstantCommand(() -> {
+                    int startposn = RobotContainer.mainShufflePage.getStartPositionIndex();
+                    Pose2d startpose;
+                    switch (startposn) {
+                        case 0: // Right Bump
+                            startpose = new Pose2d(3.42, 2.33, new Rotation2d(Math.toRadians(45.0)));
+                            break;
+                        case 1: // Left Bump
+                            startpose = new Pose2d(3.42, 5.72, new Rotation2d(Math.toRadians(315.0)));
+                            break;
+                        case 2: // Trench Right
+                            startpose = new Pose2d(3.42, 0.63, new Rotation2d(Math.toRadians(180.0)));
+                            break;
+                        case 3: // Trench Left
+                            startpose = new Pose2d(3.42, 7.42, new Rotation2d(Math.toRadians(300.0)));
+                            break;
+                        default:
+                            startpose = new Pose2d(3.42, 5.72, new Rotation2d(Math.toRadians(315.0)));
+                    }
+                    ;
+                    // Mirror for alliance natively
+                    startpose = AutoFunctions.redVsBlue(startpose);
+                    RobotContainer.odometry.setPose(startpose);
+                }),
+
+                // 2. Enable Tag Detection
+                new InstantCommand(() -> RobotContainer.odometry.TagEnable = true),
+
+                // 3. Move to depot while intaking fuel
+                new ParallelDeadlineGroup(
+                        // Deadline: finish driving to depot
+                        new MoveToPose(1.5, 2.0, new Pose2d(1.30, 5.72, new Rotation2d(Math.toRadians(315.0)))),
+                        // Continuously run intake while driving
+                        new InstantCommand(() -> RobotContainer.intake.intake(RobotMap.Intake.INTAKE_DEPOT_SPEED))),
+
+                // 4. Stop intake once arrived at depot
+                new InstantCommand(() -> RobotContainer.intake.stop()),
+
+                // 5. Short pause to settle
+                new Pause(0.5),
+
+                // 6. Move to midpoint and face hub
+                new MoveToPose(2.0, 2.5, new Pose2d(2.36, 5.72, new Rotation2d(Math.toRadians(323.0)))),
+
+                // 7. Short pause to let turret settle
+                new Pause(0.5),
+
+                // 8. Spin up and fire
+                new ParallelCommandGroup(
+                        new ShootCommand(RobotContainer.leftShooter, RobotContainer.rightShooter),
+                        new SequentialCommandGroup(
+                                // Wait for both shooters to reach target RPS, max timeout 3s
+                                new WaitUntilCommand(() -> RobotContainer.leftShooter.isAtSpeed() &&
+                                        RobotContainer.rightShooter.isAtSpeed()).withTimeout(3.0),
+
+                                // Push fuel in
+                                new UptakeAndFeed(RobotContainer.hopperFeed, RobotContainer.uptake),
+
+                                // Keep running feed
+                                new Pause(6.0))),
+
+                // 9. Disable Tag Detection at end
+                new InstantCommand(() -> RobotContainer.odometry.TagEnable = false));
+    }
+}

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -79,6 +79,13 @@ public class IntakeSubsystem extends SubsystemBase {
         intakeMotor.set(RobotMap.Intake.INTAKE_SPEED);
     }
 
+    /** Runs intake at a custom speed (0.0 - 1.0). */
+    public void intake(double speed) {
+        if (intakeMotor != null) {
+            intakeMotor.set(speed);
+        }
+    }
+
     /**
      * Runs the intake to eject game pieces.
      */

--- a/src/main/java/frc/robot/subsystems/MainShuffleBoardTab.java
+++ b/src/main/java/frc/robot/subsystems/MainShuffleBoardTab.java
@@ -133,8 +133,7 @@ public class MainShuffleBoardTab extends SubsystemBase {
         m_autonomousPath.addOption("Do Nothing",0);
         m_autonomousPath.addOption("Version A",1);
         m_autonomousPath.addOption("Version B", 2);
-        //m_autonomousPath.addOption("Off Line & Shoot Preloads", 2);
-        //m_autonomousPath.addOption("Preloads and Humen Station", 3);;
+        m_autonomousPath.addOption("Back Up & Shoot", 3);
         m_autonomousPath.setDefaultOption("Do Nothing", 0);
 
         // add selection box of paths

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -165,4 +165,13 @@ public class Shooter extends SubsystemBase {
   public double getTargetSpeed() {
     return targetSpeed;
   }
+
+  private static final double AT_SPEED_TOLERANCE_RPS = 3.0; // tune
+
+  /** Returns true when the flywheel is within tolerance of its commanded speed. */
+  public boolean isAtSpeed() {
+      return commanded >= 15.0
+          && Math.abs(getVelocity() - commanded) < AT_SPEED_TOLERANCE_RPS;
+  }
+
 }


### PR DESCRIPTION
Implements the new BackUpAndShoot autonomous command for the provincial competition.\n\n- Starts at Shuffleboard position\n- Intakes while backing up to the depot\n- Uses tunable INTAKE_DEPOT_SPEED\n- Checks shooter 'isAtSpeed()' before running uptake\n- Registered as index 3 in MainShuffleBoardTab